### PR TITLE
Only publish if version file changes

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -47,10 +47,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+    - name: Get changed files
+      id: changed-files
+      uses: jitterbit/get-changed-files@v1
+      with:
+        format: space-delimited
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      if: contains(steps.changed-files.outputs.modified, '_version.py')
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
Right now if we merge a change to the repo, GitHub Actions tries to publish to PyPI. If the version number hasn't changed, e.g. because we are just changing the name of the default branch on GitHub and not actually changing the library, that step will fail and the README badge will show a failure.

This PR adds a step to the GitHub actions to check whether `_version.py` has changed and only try to publish to PyPI if it has so that we don't get those spurious CI/CD Failures.

We did the same thing in Wildebeest, and it seems to be working as expected.

Pull Request Checklist
 - [ ] ~All tests in the `tests` folder pass with a local build~ irrelevant
 - [x] Pull request includes a description of why we are doing this
 - [x] Init files import new capabilities to appropriate level of package (if applicable)
 - [ ] ~CHANGELOG has been updated~ not applicable
 - [ ] ~Version in `_version.py` has been updated~ not applicable
 - [x] README has been updated (if applicable)
 - [x] `requirements.txt` and `requirements-dev.txt` have been recompiled if requirements in `setup.py` or `requirements-dev.in` changed.
