### PR TITLE
Remove `python@3.9` from GitHub Actions workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
It's not supported in `tokenizers`, so we shouldn't be using it with Octopod. 

https://pypi.org/project/tokenizers/ 

Pull Request Checklist
 - [X] All tests in the `tests` folder pass with a local build
 - [X] Pull request includes a description of why we are doing this
 - [ ] Init files import new capabilities to appropriate level of package (if applicable)
 - [ ] CHANGELOG has been updated
 - [ ] Version in `_version.py` has been updated
 - [ ] README has been updated (if applicable)
 - [ ] `requirements.txt` and `requirements-dev.txt` have been recompiled if requirements in `setup.py` or `requirements-dev.in` changed. 